### PR TITLE
Update README to reflect the latest arguments and output

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,65 +12,71 @@ prior to installing this.
 
 
 ### Usage
-Run `argon2 -h` for a quick help on usage and arguments:
+Run `argon2-cli -h` for a quick help on usage and arguments:
 ```bash
-$ argon2 -h
-usage: argon2 salt [-d] [-t iterations] [-m memory] [-p parallelism]
-	Password is read from stdin
+$ argon2-cli -h
+usage: argon2-cli [-h] salt [-i|-d|-id] [-t iterations] [-m log2(memory in KiB) | -k memory in KiB] [-p parallelism] [-l hash length] [-e|-r] [-v (10|13)]
+  Password is read from stdin
 
 Positional arguments:
   salt
 
 Optional arguments:
-  -h, --help     Show this help message and exit.
-  -d, --argon2d  Use Argon2d instead of Argon2i (default: false)
-  -m N           Sets the memory usage to 2^N KiB (default: 12)
-  -t N           Sets the number of iterations to N (default: 3)
-  -p N           Sets parallelism to N threads (default: 1)
-  -q             Do not output timing information (default: false)
+  -h, --help  Show this help message and exit.
+  -i          Use Argon2i (this is the default)
+  -d          Use Argon2d instead of Argon2i
+  -id         Use Argon2id instead of Argon2i
+  -t N        Sets the number of iterations to N (default 3)
+  -m N        Sets the memory usage to 2^N KiB (default 12)
+  -k N        Sets the memory usage to N KiB (default 4096)
+  -p N        Sets parallelism to N threads (default 1)
+  -l N        Sets hash output length to N bytes (default 32)
+  -e          Output only encoded hash
+  -r          Output only the raw bytes of the hash
+  -v (10|13)  Argon2 version (defaults to the most recent version, currently 13)
 ```
 
 To hash a password:
 ```bash
-$ echo -n "password" | argon2
-Type:           Argon2i
-Iterations:     3
-Memory:         4096 KiB
-Parallelism:    1
-Encoded:        $argon2i$m=4096,t=3,p=1$cZVXCGXwTBcocU4aOhjMkQ$HSAo4K9SAYUTdl/GWluOJNthqmTk1YmzNQHpZPp9sn8
+$ echo -n "password" | argon2-cli
+Type: 		Argon2i
+Iterations: 	3
+Memory: 	4096 KiB
+Parallelism: 	1
+Encoded: 	$argon2i$v=19$m=4096,t=3,p=1$lwEEWp+MVB8ha79mVt8Gog$KXc3+y9Lg4YBm0C1nxk7t6j3ku4pw/uyd4RfVq3e8yI
 0.010 seconds
 Verification ok
 ```
 
-By default, the output is verbose. You can output the hash only with `-q`:
+By default, the output is verbose. You can output the hash only with `-e`:
 ```bash
-$ echo -n "password" | argon2 -q
-$argon2i$m=4096,t=3,p=1$BFUGTNcvBjSAtYklcJFhZQ$lQsmd5Fjef2/4UTFlgXLNb8D7iFFgt0PvYVsgn+6lLs
+$ echo -n "password" | argon2-cli -e
+$argon2i$v=19$m=4096,t=3,p=1$wST5QhBgk2lu1ih4DMuxvg$LS1alrVdIWtvZHwnzCM1DUGg+5DTO3Dt1d5v9XtLws4
 ```
 
-You can choose between Argon2i and Argon2d by using the `--argon2d` (`-d`) flag:
+You can choose between Argon2i and Argon2d by using the `-d` flag:
 ```bash
-$ echo -n "password" | argon2 -d -q
-$argon2d$m=4096,t=3,p=1$x7OyWwTq0HryCyqahgZcMA$25HOolJnT/uBw4kK2rKZ4IanAA8eAYqUcg+9o0lIj2g
+$ echo -n "password" | argon2-cli -d -e
+$argon2d$v=19$m=4096,t=3,p=1$diS6FEpcDzlFacSfAHyWSw$+JLnSo3YQP/CJ7g2cRSx6YjC1eRmxHPETmd99R6eaa8
 ```
 
 You can provide your own salt as the positional argument. It is **highly**
 recommended to use the generated salt instead of a hardcoded salt, though:
 ```bash
-$ echo -n "password" | argon2 somesalt -q
-$argon2i$m=4096,t=3,p=1$c29tZXNhbHQ$vpOd0mbc3AzXEHMgcTb1CrZt5XuoRQuz1kQtGBv7ejk
+$ echo -n "password" | argon2-cli somesalt -e
+$argon2i$v=19$m=4096,t=3,p=1$c29tZXNhbHQ$iWh06vD8Fy27wf9npn6FXWiCX4K6pW6Ue1Bnzz07Z8A
 ```
 
 You can also modify time, memory and parallelism constraints with `-t`, `-m` and
 `-p` respectively, followed by a valid number:
 ```bash
-$ echo -n "password" | ./cli.js -t 2 -m 16 -p 4
-Type:           Argon2i
-Iterations:     2
-Memory:         65536 KiB
-Parallelism:    4
-Encoded:        $argon2i$m=65536,t=2,p=4$/tH9944/9OdsUauNaTVgfw$Glxg3SkUfkLETBHxaq1GamsaTBiYdBNRppL2Mqm7hqo
-0.077 seconds
+$ echo -n "password" | argon2-cli -t 2 -k 65536 -p 4
+Type: 		Argon2i
+Iterations: 	2
+Memory: 	65536 KiB
+Parallelism: 	4
+Encoded: 	$argon2i$v=19$m=65536,t=2,p=4$1LoWDI7KvUoSIUlA+26nHw$KK1P9iYjYn8+FE1ACGWFNhC3UfJsc1LYS7ciMcxS7EA
+0.058 seconds
 Verification ok
 ```
 


### PR DESCRIPTION
I updated the README with the following changes:
* use `argon2-cli` instead of `argon2`
* replace all of the output with what the latest version generates
* update the deprecated `-q` flag to `-e`
* fix the memory usage example to use `-k` instead of `-m` because `-m` does not seem to change anything